### PR TITLE
use PHPickerView for gallery selection instead of UIImagePicker to simplify permission handling for location metadata

### DIFF
--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <PhotosUI/PhotosUI.h>
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 #import <CoreLocation/CLLocationManager.h>
@@ -64,6 +65,18 @@ typedef NSUInteger CDVMediaType;
 
 @end
 
+API_AVAILABLE(ios(14))
+@interface CDVGalleryPicker : NSObject <UIAdaptivePresentationControllerDelegate>
+
+@property (strong) PHPickerViewController* pickerViewController;
+
+@property (strong) CDVPictureOptions* pictureOptions;
+@property (copy) NSString* callbackId;
+
++ (instancetype) createFromPictureOptions:(CDVPictureOptions*)options;
+
+@end
+
 @interface CDVCameraPicker : UIImagePickerController <UIAdaptivePresentationControllerDelegate>
 
 @property (strong) CDVPictureOptions* pictureOptions;
@@ -83,10 +96,11 @@ typedef NSUInteger CDVMediaType;
 @interface CDVCamera : CDVPlugin <UIImagePickerControllerDelegate,
                        UINavigationControllerDelegate,
                        UIPopoverControllerDelegate,
-                       CLLocationManagerDelegate>
+                       CLLocationManagerDelegate,
+                       PHPickerViewControllerDelegate>
 {}
-
 @property (strong) CDVCameraPicker* pickerController;
+@property (strong) CDVGalleryPicker* galleryPicker;
 @property (strong) NSMutableDictionary *metadata;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property (strong) NSData* data;


### PR DESCRIPTION
- if required extendable to other destination and mediatypes

### Platforms affected
iOS >= 14.0

### What does this PR do?
use PHPicker to enable access to location metadata even if permission not given

### What testing has been done on this change?
basic usability

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
