### PR TITLE
FIA-2059: propagate pictureOptions for import from gallery

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -967,11 +967,14 @@ CFStringRef kuTTypeFromCDVEncodingType(CDVEncodingType encoding) {
 
 + (instancetype) createFromPictureOptions:(CDVPictureOptions*)pictureOptions {
     CDVGalleryPicker* instance = [[CDVGalleryPicker alloc] init];
+    instance.pictureOptions = pictureOptions;
+    
     PHPickerConfiguration* singleImage = [[PHPickerConfiguration alloc] initWithPhotoLibrary:PHPhotoLibrary.sharedPhotoLibrary];
     singleImage.filter = PHPickerFilter.imagesFilter;
     singleImage.selectionLimit = 1;
     instance.pickerViewController = [[PHPickerViewController alloc] initWithConfiguration:singleImage];
     instance.pickerViewController.presentationController.delegate = instance;
+    
     return instance;
 }
 


### PR DESCRIPTION
### Platforms affected
- iOS >= 14.0

### What does this PR do?
- fix ignoring of picture options during import with PHPicker

### What testing has been done on this change?
- basic usability (rotation and resizing handled correctly)

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
