### PR TITLE
Workaround for Android 14 image picker stripping EXIF information

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -205,7 +205,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
                     String[] permissions = getPermissions(true, mediaType);
-                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                         PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, permissions);
                     } else {
                         this.getImage(this.srcType, destType);
@@ -456,7 +456,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
                 } else {
                     intent.setAction(Intent.ACTION_GET_CONTENT);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1097,7 +1097,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         try {
             String mimeType = FileHelper.getMimeType(imageUrl.toString(), cordova);
-            if (JPEG_MIME_TYPE.equalsIgnoreCase(mimeType)) {
+            if (JPEG_MIME_TYPE.equalsIgnoreCase(mimeType) || HEIC_MIME_TYPE.equalsIgnoreCase(mimeType)) {
                 //  ExifInterface doesn't like the file:// prefix
                 String filePath = galleryUri.toString().replace("file://", "");
                 // read exifData of source

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -205,7 +205,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
                     String[] permissions = getPermissions(true, mediaType);
-                    if(!hasPermissions(permissions)) {
+                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                         PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, permissions);
                     } else {
                         this.getImage(this.srcType, destType);
@@ -456,7 +456,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
-                intent.setAction(Intent.ACTION_GET_CONTENT);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
+                } else {
+                    intent.setAction(Intent.ACTION_GET_CONTENT);
+                }
                 intent.addCategory(Intent.CATEGORY_OPENABLE);
             }
         } else if (this.mediaType == VIDEO) {


### PR DESCRIPTION
- Do not use the new picker because it strips EXIF information
- Do not request Storage permission, because its unnecessary with file Intent on newer Android versions