### PR TITLE
Change picker to Finder for import when running on macOS

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -205,7 +205,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
                     String[] permissions = getPermissions(true, mediaType);
-                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                         PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, permissions);
                     } else {
                         this.getImage(this.srcType, destType);
@@ -456,7 +456,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
                 } else {
                     intent.setAction(Intent.ACTION_GET_CONTENT);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1097,7 +1097,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         try {
             String mimeType = FileHelper.getMimeType(imageUrl.toString(), cordova);
-            if (JPEG_MIME_TYPE.equalsIgnoreCase(mimeType)) {
+            if (JPEG_MIME_TYPE.equalsIgnoreCase(mimeType) || HEIC_MIME_TYPE.equalsIgnoreCase(mimeType)) {
                 //  ExifInterface doesn't like the file:// prefix
                 String filePath = galleryUri.toString().replace("file://", "");
                 // read exifData of source

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -205,7 +205,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
                     String[] permissions = getPermissions(true, mediaType);
-                    if(!hasPermissions(permissions)) {
+                    if(!hasPermissions(permissions) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                         PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, permissions);
                     } else {
                         this.getImage(this.srcType, destType);
@@ -456,7 +456,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
-                intent.setAction(Intent.ACTION_GET_CONTENT);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
+                } else {
+                    intent.setAction(Intent.ACTION_GET_CONTENT);
+                }
                 intent.addCategory(Intent.CATEGORY_OPENABLE);
             }
         } else if (this.mediaType == VIDEO) {

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -68,7 +68,7 @@ typedef NSUInteger CDVMediaType;
 API_AVAILABLE(ios(14))
 @interface CDVGalleryPicker : NSObject <UIAdaptivePresentationControllerDelegate>
 
-@property (strong) PHPickerViewController* pickerViewController;
+@property (strong) UIViewController* pickerViewController;
 
 @property (strong) CDVPictureOptions* pictureOptions;
 @property (copy) NSString* callbackId;
@@ -97,7 +97,8 @@ API_AVAILABLE(ios(14))
                        UINavigationControllerDelegate,
                        UIPopoverControllerDelegate,
                        CLLocationManagerDelegate,
-                       PHPickerViewControllerDelegate>
+                       PHPickerViewControllerDelegate,
+                       UIDocumentPickerDelegate>
 {}
 @property (strong) CDVCameraPicker* pickerController;
 @property (strong) CDVGalleryPicker* galleryPicker;

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -472,7 +472,7 @@ CFStringRef kuTTypeFromCDVEncodingType(CDVEncodingType encoding) {
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller
 didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
-    __weak CDVCamera* weakSelf = self;
+    CDVCamera* weakSelf = self;
     
     if (urls.count > 0) {
         NSURL *fileURL = [urls firstObject];
@@ -481,7 +481,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
         NSData *data = [NSData dataWithContentsOfURL:fileURL options:NSDataReadingMappedIfSafe error:&error];
         
         if (error) {
-            [self sendErrorResultWithMessage];
+            [self onEndSelectionWithoutImage];
             return;
         }
         
@@ -489,15 +489,15 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
         UIImage *original = [[UIImage alloc] initWithData:data];
         [self handleImageFromPicker:original withData:data];
     } else {
-        [self sendErrorResultWithMessage];
+        [self onEndSelectionWithoutImage];
     }
 }
 
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller; {
-    [self sendErrorResultWithMessage];
+    [self onEndSelectionWithoutImage];
 }
 
-- (void)sendErrorResultWithMessage {
+- (void)onEndSelectionWithoutImage {
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No Image Selected"];
     [self.commandDelegate sendPluginResult:result callbackId:self.galleryPicker.callbackId];
     
@@ -508,7 +508,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
 
 - (void)handleImageFromPicker:(UIImage *)original withData:(NSData *)data {
     
-    __weak CDVCamera* weakSelf = self;
+    CDVCamera* weakSelf = self;
     
     UIImage* image = [weakSelf conformImage:original toOptions:weakSelf.galleryPicker.pictureOptions];
                     
@@ -565,10 +565,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
                 [self handleImageFromPicker:original withData:data];
             }];
         } else {
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No Image Selected"];
-            [self.commandDelegate sendPluginResult:result callbackId:self.galleryPicker.callbackId];
-            self.hasPendingOperation = NO;
-            self.galleryPicker = nil;
+            [self onEndSelectionWithoutImage];
         }
     }];
 }


### PR DESCRIPTION
When running on macOS as an emulated iOS app we can use the Finder for picking image.

Till now the user could only chose from images in Apple Photos.

Now the user can chose from the whole filesystem. (But only files with image extension)