### PR TITLE
Postprocessing Respecting Color Profiles

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -686,7 +686,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
         NSLog(@"Image standardization failed. Continuing with original.");
         standardized = original;
     }
-    [self logImageManipulationStep:standardized named:@"b-standardized.jpg"];
+    // [self logImageManipulationStep:standardized named:@"b-standardized.jpg"];
 
     UIImage* scaledImage = nil;
     if ((options.targetSize.width > 0) && (options.targetSize.height > 0)) {

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -242,13 +242,13 @@ CFStringRef kuTTypeFromCDVEncodingType(CDVEncodingType encoding) {
         [weakSelf requestPhotoPermissions:^(bool auth) {
             // Perform UI operations on the main thread
             dispatch_async(dispatch_get_main_queue(), ^{
-		        CDVCameraPicker* cameraPicker = [CDVCameraPicker createFromPictureOptions:pictureOptions];
-		        weakSelf.pickerController = cameraPicker;
+                CDVCameraPicker* cameraPicker = [CDVCameraPicker createFromPictureOptions:pictureOptions];
+                weakSelf.pickerController = cameraPicker;
 
-		        cameraPicker.delegate = weakSelf;
-		        cameraPicker.callbackId = command.callbackId;
-		        // we need to capture this state for memory warnings that dealloc this object
-		        cameraPicker.webView = weakSelf.webView;
+                cameraPicker.delegate = weakSelf;
+                cameraPicker.callbackId = command.callbackId;
+                // we need to capture this state for memory warnings that dealloc this object
+                cameraPicker.webView = weakSelf.webView;
                 // If a popover is already open, close it; we only want one at a time.
                 if (([[weakSelf pickerController] pickerPopoverController] != nil) && [[[weakSelf pickerController] pickerPopoverController] isPopoverVisible]) {
                     [[[weakSelf pickerController] pickerPopoverController] dismissPopoverAnimated:YES];
@@ -472,8 +472,6 @@ CFStringRef kuTTypeFromCDVEncodingType(CDVEncodingType encoding) {
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller
 didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
-    CDVCamera* weakSelf = self;
-    
     if (urls.count > 0) {
         NSURL *fileURL = [urls firstObject];
         
@@ -671,19 +669,34 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
     return [self conformImage:image toOptions:options];
 }
 
-- (UIImage*)conformImage:(UIImage*)original toOptions:(CDVPictureOptions*)options {
-    if (options.correctOrientation) {
-        original = [original imageCorrectedForCaptureOrientation];
-    }
+- (void)logImageManipulationStep:(UIImage*)image named:(NSString*)name {
+    NSString* cache = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    NSString* path = [cache stringByAppendingPathComponent:name];
     
+    NSError *imageError = nil;
+    NSData *imageData = UIImageJPEGRepresentation(image, 1.00f);
+    [imageData writeToFile:path options:NSDataWritingAtomic error:&imageError];
+}
+
+- (UIImage*)conformImage:(UIImage*)original toOptions:(CDVPictureOptions*)options {
+    // [self logImageManipulationStep:original named:@"a-original.jpg"];
+    
+    UIImage* standardized = [original imageStandardizedWithOrientation:options.correctOrientation];
+    if (!standardized) {
+        NSLog(@"Image standardization failed. Continuing with original.");
+        standardized = original;
+    }
+    [self logImageManipulationStep:standardized named:@"b-standardized.jpg"];
+
     UIImage* scaledImage = nil;
     if ((options.targetSize.width > 0) && (options.targetSize.height > 0)) {
         if (options.cropToSize) {
-            scaledImage = [original imageByScalingAndCroppingForSize:options.targetSize];
+            scaledImage = [standardized imageByScalingAndCroppingForSize:options.targetSize];
         } else {
-            scaledImage = [original imageByScalingNotCroppingForSize:options.targetSize];
+            scaledImage = [standardized imageByScalingNotCroppingForSize:options.targetSize];
         }
     }
+    // [self logImageManipulationStep:scaledImage named:@"c-scaled.jpg"];
 
     return (scaledImage == nil ? original : scaledImage);
 }
@@ -810,15 +823,15 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls; {
 
 - (CLLocationManager*)locationManager
 {
-	if (locationManager != nil) {
-		return locationManager;
-	}
+    if (locationManager != nil) {
+        return locationManager;
+    }
 
-	locationManager = [[CLLocationManager alloc] init];
-	[locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
-	[locationManager setDelegate:self];
+    locationManager = [[CLLocationManager alloc] init];
+    [locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
+    [locationManager setDelegate:self];
 
-	return locationManager;
+    return locationManager;
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateToLocation:(CLLocation*)newLocation fromLocation:(CLLocation*)oldLocation

--- a/src/ios/UIImage+CropScaleOrientation.h
+++ b/src/ios/UIImage+CropScaleOrientation.h
@@ -21,6 +21,7 @@
 
 @interface UIImage (CropScaleOrientation)
 
+- (UIImage*)imageStandardizedWithOrientation:(bool)reorient;
 - (UIImage*)imageByScalingAndCroppingForSize:(CGSize)targetSize;
 - (UIImage*)imageCorrectedForCaptureOrientation;
 - (UIImage*)imageCorrectedForCaptureOrientation:(UIImageOrientation)imageOrientation;

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -21,6 +21,44 @@
 
 @implementation UIImage (CropScaleOrientation)
 
+- (UIImage*)imageStandardizedWithOrientation:(bool)reorient
+{
+    NSDictionary* imageOptions = nil;
+    
+    if (reorient) {
+        CGImagePropertyOrientation orientation = CGImagePropertyOrientationForUIImageOrientation(self.imageOrientation);
+        
+        imageOptions = @{
+            kCIImageApplyOrientationProperty : @true,
+            kCIImageProperties : @{
+                (__bridge NSString*)kCGImagePropertyOrientation : @(orientation)
+            }
+        };
+    }
+    
+    CIImage* reorientated = [[CIImage alloc]
+        initWithImage:self
+        options:imageOptions
+    ];
+    
+    CIContext* context = [CIContext contextWithOptions:nil];
+    CGImageRef colorCorrected = [context
+        createCGImage:reorientated
+        fromRect:[reorientated extent]
+        format:kCIFormatRGBA8
+        colorSpace:CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
+    ];
+    
+    if (!colorCorrected) {
+        return nil;
+    }
+    
+    UIImage* standardized = [UIImage imageWithCGImage:colorCorrected];
+    CGImageRelease(colorCorrected);
+    
+    return standardized;
+}
+
 - (UIImage*)imageByScalingAndCroppingForSize:(CGSize)targetSize
 {
     UIImage* sourceImage = self;
@@ -54,73 +92,129 @@
             thumbnailPoint.x = (targetWidth - scaledWidth) * 0.5;
         }
     }
-    
-    UIGraphicsBeginImageContext(targetSize); // this will crop
-    
+        
     CGRect thumbnailRect = CGRectZero;
     thumbnailRect.origin = thumbnailPoint;
     thumbnailRect.size.width = scaledWidth;
     thumbnailRect.size.height = scaledHeight;
+
+    CGFloat scale = [UIScreen mainScreen].scale;
+    CGColorSpaceRef colorSpace = CGImageGetColorSpace(sourceImage.CGImage);
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(sourceImage.CGImage);
     
-    [sourceImage drawInRect:thumbnailRect];
+    CGContextRef context = CGBitmapContextCreate(
+        NULL,
+        targetSize.width,
+        targetSize.height,
+        CGImageGetBitsPerComponent(sourceImage.CGImage),
+        0,
+        colorSpace,
+        bitmapInfo
+    );
+
+    if (!context) {
+        // this will ignore color space used in source and probably fallback to sRGB
+        NSLog(@"Falling back to UIGraphicsImageContext: propably ignoring color profile");
+        UIGraphicsBeginImageContext(targetSize);
+        context = UIGraphicsGetCurrentContext();
+    }
+
+    CGContextDrawImage(context, thumbnailRect, sourceImage.CGImage);
+
+    CGImageRef cgImage = CGBitmapContextCreateImage(context);
+    newImage = [UIImage
+        imageWithCGImage:cgImage
+        scale:scale
+        orientation:UIImageOrientationUp
+    ];
     
-    newImage = UIGraphicsGetImageFromCurrentImageContext();
     if (newImage == nil) {
-        NSLog(@"could not scale image");
+        NSLog(@"could not scale and crop image");
     }
     
-    // pop the context to get back to the default
+    CGImageRelease(cgImage);
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    
+    UIGraphicsPopContext();
     UIGraphicsEndImageContext();
+    
     return newImage;
 }
 
 - (UIImage*)imageCorrectedForCaptureOrientation:(UIImageOrientation)imageOrientation
 {
-    float rotation_radians = 0;
-    bool perpendicular = false;
+    float rotationInRadiens = 0;
+    bool aspectChange = false;
     
     switch (imageOrientation) {
         case UIImageOrientationUp :
-            rotation_radians = 0.0;
+            rotationInRadiens = 0.0;
             break;
             
         case UIImageOrientationDown:
-            rotation_radians = M_PI; // don't be scared of radians, if you're reading this, you're good at math
+            rotationInRadiens = M_PI; // don't be scared of radians, if you're reading this, you're good at math
             break;
             
         case UIImageOrientationRight:
-            rotation_radians = M_PI_2;
-            perpendicular = true;
+            rotationInRadiens = -M_PI_2;
+            aspectChange = true;
             break;
             
         case UIImageOrientationLeft:
-            rotation_radians = -M_PI_2;
-            perpendicular = true;
+            rotationInRadiens = M_PI_2;
+            aspectChange = true;
             break;
             
         default:
             break;
     }
     
-    UIGraphicsBeginImageContext(CGSizeMake(self.size.width, self.size.height));
-    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGImageRef sourceImage = self.CGImage;
+
+    CGColorSpaceRef colorSpace = CGImageGetColorSpace(sourceImage);
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(sourceImage);
     
-    // Rotate around the center point
-    CGContextTranslateCTM(context, self.size.width / 2, self.size.height / 2);
-    CGContextRotateCTM(context, rotation_radians);
+    CGSize bitmapSize = aspectChange ? CGSizeMake(self.size.height, self.size.width) : self.size;
+    NSLog(@"Got image size %@ and bitmap size %@", NSStringFromCGSize(bitmapSize), NSStringFromCGSize(bitmapSize));
     
-    CGContextScaleCTM(context, 1.0, -1.0);
-    float width = perpendicular ? self.size.height : self.size.width;
-    float height = perpendicular ? self.size.width : self.size.height;
-    CGContextDrawImage(context, CGRectMake(-width / 2, -height / 2, width, height), [self CGImage]);
-    
-    // Move the origin back since the rotation might've change it (if its 90 degrees)
-    if (perpendicular) {
-        CGContextTranslateCTM(context, -self.size.height / 2, -self.size.width / 2);
+    CGContextRef context = CGBitmapContextCreate(
+        NULL,
+        self.size.width,
+        self.size.height,
+        CGImageGetBitsPerComponent(sourceImage),
+        0,
+        colorSpace,
+        bitmapInfo
+    );
+
+    if (!context) {
+        // this will ignore color space used in source and probably fallback to sRGB
+        NSLog(@"Falling back to UIGraphicsImageContext: propably ignoring color profile");
+        UIGraphicsBeginImageContext(self.size);
+        context = UIGraphicsGetCurrentContext();
     }
     
-    UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
+    CGContextTranslateCTM(context, self.size.width/2, self.size.height/2);
+    CGContextRotateCTM(context, rotationInRadiens);
+    
+    CGRect drawRect = CGRectMake(-bitmapSize.width/2, -bitmapSize.height/2, bitmapSize.width, bitmapSize.height);
+    CGContextDrawImage(context, drawRect, self.CGImage);
+    
+    CGImageRef rotatedImageRef = CGBitmapContextCreateImage(context);
+    UIImage *newImage = [UIImage imageWithCGImage:rotatedImageRef scale:self.scale orientation:UIImageOrientationUp];
+    
+    if (newImage == nil) {
+        NSLog(@"could not rotate image");
+    }
+
+    CGImageRelease(rotatedImageRef);
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    
+    UIGraphicsPopContext();
     UIGraphicsEndImageContext();
+
     return newImage;
 }
 
@@ -162,18 +256,56 @@
     scaledSize.width = (int)scaledSize.width;
     scaledSize.height = (int)scaledSize.height;
     
-    UIGraphicsBeginImageContext(scaledSize); // this will resize
+    CGColorSpaceRef colorSpace = CGImageGetColorSpace(sourceImage.CGImage);
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(sourceImage.CGImage);
     
-    [sourceImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
+    CGContextRef context = CGBitmapContextCreate(
+        NULL,
+        scaledSize.width,
+        scaledSize.height,
+        CGImageGetBitsPerComponent(sourceImage.CGImage),
+        0,
+        colorSpace,
+        bitmapInfo
+    );
+
+    if (!context) {
+        // this will ignore color space used in source and probably fallback to sRGB
+        NSLog(@"Falling back to UIGraphicsImageContext: propably ignoring color profile");
+        UIGraphicsBeginImageContext(scaledSize);
+        context = UIGraphicsGetCurrentContext();
+    }
     
-    newImage = UIGraphicsGetImageFromCurrentImageContext();
+    CGRect drawRect = CGRectMake(0, 0, scaledSize.width, scaledSize.height);
+    CGContextDrawImage(context, drawRect, self.CGImage);
+    
+    CGImageRef rotatedImageRef = CGBitmapContextCreateImage(context);
+    newImage = [UIImage imageWithCGImage:rotatedImageRef scale:self.scale orientation:UIImageOrientationUp];
+    
     if (newImage == nil) {
         NSLog(@"could not scale image");
     }
     
-    // pop the context to get back to the default
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    
+    UIGraphicsPopContext();
     UIGraphicsEndImageContext();
+    
     return newImage;
+}
+
+CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIImageOrientation orientation) {
+    switch (orientation) {
+        case UIImageOrientationUp: return kCGImagePropertyOrientationUp;
+        case UIImageOrientationDown: return kCGImagePropertyOrientationDown;
+        case UIImageOrientationLeft: return kCGImagePropertyOrientationLeft;
+        case UIImageOrientationRight: return kCGImagePropertyOrientationRight;
+        case UIImageOrientationUpMirrored: return kCGImagePropertyOrientationUpMirrored;
+        case UIImageOrientationDownMirrored: return kCGImagePropertyOrientationDownMirrored;
+        case UIImageOrientationLeftMirrored: return kCGImagePropertyOrientationLeftMirrored;
+        case UIImageOrientationRightMirrored: return kCGImagePropertyOrientationRightMirrored;
+    }
 }
 
 @end


### PR DESCRIPTION
Images imported by user are converted to sRGB and manipulation methods extended to respect and retain the color profile of the original image. Has (close to) no effect on classification result. May be useful if you want to at some point respect color profile during inference (tensorflow by default does not, seen as augmentation?).
